### PR TITLE
Remove unnecessary static map from event class

### DIFF
--- a/event.h
+++ b/event.h
@@ -22,10 +22,6 @@ public:
 
     ~Event();
 
-private:
-    static map<string, int> activities; // allows for pruning of 0 each week
 };
-
-map<string, int> Event::activities;
 
 #endif // EVENT_H


### PR DESCRIPTION
Forgot to remove on last commit when reworking the base classes